### PR TITLE
CSI GPIOs for Olimex IMX8MP

### DIFF
--- a/board/olimex/imx8mp/linux/0001-dts-add-imx8mp-olimex.patch
+++ b/board/olimex/imx8mp/linux/0001-dts-add-imx8mp-olimex.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000..a340f64
 --- /dev/null
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-olimex.dts
-@@ -0,0 +1,1166 @@
+@@ -0,0 +1,1160 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright 2019 NXP
@@ -1066,21 +1066,15 @@ index 0000000..a340f64
 +		>;
 +	};
 +
-+	pinctrl_csi0_pwn: csi0_pwn_grp {
++	pinctrl_csi0_en: csi0_en_grp {
 +		fsl,pins = <
-+			MX8MP_IOMUXC_SD1_STROBE__GPIO2_IO11	0x19
++			MX8MP_IOMUXC_GPIO1_IO05__GPIO1_IO05		0x10
 +		>;
 +	};
 +
-+	pinctrl_csi0_rst: csi0_rst_grp {
++	pinctrl_csi1_en: csi1_en_grp {
 +		fsl,pins = <
-+			MX8MP_IOMUXC_GPIO1_IO06__GPIO1_IO06		0x19
-+		>;
-+	};
-+
-+	pinctrl_csi_mclk: csi_mclk_grp {
-+		fsl,pins = <
-+			MX8MP_IOMUXC_GPIO1_IO15__CCM_CLKO2	0x59
++			+MX8MP_IOMUXC_GPIO1_IO06__GPIO1_IO06		0x10
 +		>;
 +	};
 +};


### PR DESCRIPTION
I've added the CSI GPIO pins (`CAMx_EN`) to the device tree in accordance to the schematic:
![image](https://github.com/user-attachments/assets/937a3be8-8a97-40d3-b0ee-95da95e5aa81)

The previous segment was apparently from NXP's EVK. In contrast to it, Olimex SoM doesn't have a master clock output and only pins a single GPIO out. 

Tested against IMX219 on CSI0 (can't test on CSI1 with this camera because it collides at `0x10` with some sensor already on the bus on the evaluation board).