### PR TITLE
Deterministic SPI order for IMX8MP

### DIFF
--- a/board/olimex/imx8mp/linux/0001-dts-add-imx8mp-olimex.patch
+++ b/board/olimex/imx8mp/linux/0001-dts-add-imx8mp-olimex.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000..a340f64
 --- /dev/null
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-olimex.dts
-@@ -0,0 +1,1160 @@
+@@ -0,0 +1,1168 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright 2019 NXP
@@ -20,6 +20,14 @@ index 0000000..a340f64
 +
 +	chosen {
 +		stdout-path = &uart2;
++	};
++
++	aliases {
++		spi1 = &ecspi1;
++		spi2 = &ecspi2;
++		spi3 = &ecspi3;
++		can0 = &flexcan1;
++		can1 = &flexcan2;
 +	};
 +
 +	gpio-leds {


### PR DESCRIPTION
If more than 1 ecSPI interface is enabled on the SoM the probe order is random because the DTSI never had aliases for IMX8MP SPI specifically for some reason:
```
root@imx8mp:~# ls /sys/class/spi_master/spi*/device -l
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi1/device -> ../../../30820000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi2/device -> ../../../30830000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi3/device -> ../../../30840000.spi
root@imx8mp:~# reboot
root@imx8mp:~# ls /sys/class/spi_master/spi*/device -l
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi1/device -> ../../../30840000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi2/device -> ../../../30820000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi3/device -> ../../../30830000.spi
root@imx8mp:~# reboot
root@imx8mp:~# ls /sys/class/spi_master/spi*/device -l
lrwxrwxrwx 1 root root 0 Jan  8 19:26 /sys/class/spi_master/spi1/device -> ../../../30830000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:26 /sys/class/spi_master/spi2/device -> ../../../30840000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:26 /sys/class/spi_master/spi3/device -> ../../../30820000.spi
```

Backporting my change from the Freescale kernel: https://github.com/Freescale/linux-fslc/pull/764
Alternatively you can just update the kernel when the commit above is merged since it fixes the main include.

PS: mechanically applying changes from my Yocto playground, please test-build before merge. I'm sorry for the typo in the previous PR.